### PR TITLE
Support newer versions of Laravel Prompts package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^8.2",
         "knuckleswtf/scribe": "^4.35",
         "laravel/framework": "^10|^11",
-        "laravel/prompts": "^0.1.16",
+        "laravel/prompts": "^0.1|^0.2|^0.3",
         "laravel/sanctum": "^3.0|^4.0",
         "spatie/laravel-data": "^4.3",
         "spatie/laravel-package-tools": "^1.16",


### PR DESCRIPTION
Before this PR, some installs would be force to downgrade laravel/prompts from 0.32-33 to a 0.1.x version.

This PR Removes that restriction and allows up to 0.3.x released to be used

addresses #56 

